### PR TITLE
Change download URL to correct new URL

### DIFF
--- a/net.xmind.ZEN.yml
+++ b/net.xmind.ZEN.yml
@@ -60,6 +60,6 @@ modules:
 
       - type: extra-data
         filename: xmind.deb
-        url: https://dl2.xmind.cn/XMind-ZEN-for-Linux-64bit.deb
+        url: http://dl2.xmind.net/xmind-downloads/XMind-ZEN-for-Linux-64bit.deb
         sha256: abfc352bab17859c7b4d061f233db2a2b252d062cc24c6332eb1d86a5bf56069
         size: 59754534


### PR DESCRIPTION
The previous URL broke the flatpak package. This new one works correctly. SSL breaks the download; please keep as http.